### PR TITLE
Fix bitwise operation in pcapng.py

### DIFF
--- a/pcapparser/pcapng.py
+++ b/pcapparser/pcapng.py
@@ -82,7 +82,7 @@ class PcapngFile(object):
             padding_len = raw_len
             if code == 9:
                 # if_tsresol
-                if_tsresol = option[4]
+                if_tsresol = ord(option[4])
                 sig = (if_tsresol & 0x80)
                 count = if_tsresol & 0x7f
                 # we use microsecond


### PR DESCRIPTION
Got follow error
Fix with this commit
Please, pull if looks great


george@gregentov-desktop:~/svn/vtest$ ./venv/bin/parse_pcap -v /home/george/Downloads/b75c6134-3d11-449b-8ef5-b53d39bdfa62-attachment.pcap
Traceback (most recent call last):
  File "./venv/bin/parse_pcap", line 212, in <module>
    main()
  File "./venv/bin/parse_pcap", line 200, in main
    pcap_file(conn_dict, infile)
  File "./venv/bin/parse_pcap", line 125, in pcap_file
    for tcp_pac in packet_parser.read_package_r(pcap_file):
  File "/home/george/svn/vtest/venv/local/lib/python2.7/site-packages/pcapparser/packet_parser.py", line 203, in read_package_r
    for pack in read_tcp_packet(pcap_file):
  File "/home/george/svn/vtest/venv/local/lib/python2.7/site-packages/pcapparser/packet_parser.py", line 184, in read_tcp_packet
    for link_type, micro_second, link_packet in read_packet():
  File "/home/george/svn/vtest/venv/local/lib/python2.7/site-packages/pcapparser/pcapng.py", line 168, in read_packet
    data = self.parse_block()
  File "/home/george/svn/vtest/venv/local/lib/python2.7/site-packages/pcapparser/pcapng.py", line 148, in parse_block
    self.parse_interface_description_block(block_len)
  File "/home/george/svn/vtest/venv/local/lib/python2.7/site-packages/pcapparser/pcapng.py", line 86, in parse_interface_description_block
    sig = (if_tsresol & 0x80)
TypeError: unsupported operand type(s) for &: 'str' and 'int'